### PR TITLE
Replace main.ino with feather_hub.cpp as entry point

### DIFF
--- a/firmware/feather_hub.cpp
+++ b/firmware/feather_hub.cpp
@@ -1,0 +1,31 @@
+/*
+ * File: feather_hub.cpp
+ * Description: Main file for the Feather Hub project, integrating various components
+ * Author: Phoenix Volt
+ * Created: 2025-08-04
+ */
+
+// Config
+#include "config/config_current.h"
+#include "config/config_protoA.h"
+
+// Shared
+#include "shared/adc_utils.h"
+#include "shared/adc_utils.cpp"
+#include "shared/ADS1118.h"
+#include "shared/ADS1118.cpp"
+#include "shared/logger.h"
+#include "shared/voltage_utils.h"
+#include "shared/voltage_utils.cpp"
+
+// Charge
+#include "charge/charge.h"
+#include "charge/charge.cpp"
+
+// Discharge
+#include "discharge/discharge.h"
+#include "discharge/discharge.cpp"
+
+// Thermal
+#include "thermal/thermal.h"
+#include "thermal/thermal.cpp"


### PR DESCRIPTION
Removed the empty main.ino file and added feather_hub.cpp as the new main file for the Feather Hub project. The new file integrates configuration, shared utilities, charge, discharge, and thermal modules.