### PR TITLE
Update include paths in discharge.h to absolute paths

### DIFF
--- a/firmware/discharge/discharge.h
+++ b/firmware/discharge/discharge.h
@@ -9,10 +9,9 @@
 #ifndef DISCHARGE_H // Header guard to prevent multiple inclusions
     #define DISCHARGE_H
 
-    #include "../Shared/adc_utils.h"
-    #include "../Shared/debug_utils.h"
-    #include "../Shared/voltage_utils.h"
-    #include "../Config/config_protoA.h"
+    #include "C:\ashborn-forge\firmware\shared\adc_utils.h"
+    #include "C:\ashborn-forge\firmware\sharedvoltage_utils.h"
+    #include "C:\ashborn-forge\firmware\sharedconfig_protoA.h"
 
     // Initializes discharge process
     void initDischarge();


### PR DESCRIPTION
Changed relative include paths to absolute Windows-style paths in discharge.h. This may be for compatibility with a specific build environment or to resolve include path issues.